### PR TITLE
bug fix

### DIFF
--- a/pkglink/installation.py
+++ b/pkglink/installation.py
@@ -3,7 +3,6 @@ import hashlib
 import re
 import shutil
 import subprocess
-from difflib import SequenceMatcher
 from pathlib import Path
 
 from pkglink.logging import get_logger
@@ -41,219 +40,67 @@ def _should_refresh_cache(cache_dir: Path, spec: SourceSpec) -> bool:
     return not _is_immutable_reference(spec)
 
 
-def find_python_package(install_dir: Path) -> Path | None:
-    """Find the first directory with __init__.py (Python package)."""
-    logger.debug('looking_for_python_package', directory=str(install_dir))
-    for item in install_dir.iterdir():
-        if item.is_dir() and (item / '__init__.py').exists():
-            logger.debug('python_package_found', package=item.name)
-            return item
-    logger.debug('no_python_package_found', directory=str(install_dir))
-    return None
-
-
-def find_with_resources(install_dir: Path) -> Path | None:
-    """Find the first directory containing 'resources' folder."""
+def _find_exact_package_match(
+    install_dir: Path,
+    expected_name: str,
+) -> Path | None:
+    """Find a directory that exactly matches the expected package name."""
     logger.debug(
-        'looking_for_directory_with_resources',
-        directory=str(install_dir),
-    )
-    for item in install_dir.iterdir():
-        if item.is_dir() and (item / 'resources').exists():
-            logger.debug('directory_with_resources_found', directory=item.name)
-            return item
-    logger.debug(
-        'no_directory_with_resources_found',
-        directory=str(install_dir),
-    )
-    return None
-
-
-def find_exact_match(install_dir: Path, expected_name: str) -> Path | None:
-    """Find a directory that exactly matches the expected name."""
-    logger.debug(
-        'looking_for_exact_match',
+        'looking_for_exact_package_match',
         expected=expected_name,
         directory=str(install_dir),
     )
     target = install_dir / expected_name
     if target.is_dir():
-        logger.debug('exact_match_found', match=target.name)
+        logger.debug('exact_package_match_found', match=target.name)
         return target
-    logger.debug('no_exact_match_found', expected=expected_name)
+    logger.debug('no_exact_package_match_found', expected=expected_name)
     return None
 
 
-def find_by_prefix(install_dir: Path, expected_name: str) -> Path | None:
-    """Find a directory that starts with the expected name."""
-    logger.debug(
-        'looking_for_prefix_match',
-        prefix=expected_name,
-        directory=str(install_dir),
-    )
-    for item in install_dir.iterdir():
-        if item.is_dir() and item.name.startswith(expected_name):
-            logger.debug('prefix_match_found', match=item.name)
-            return item
-    logger.debug('no_prefix_match_found', expected=expected_name)
-    return None
-
-
-def find_by_suffix(install_dir: Path, expected_name: str) -> Path | None:
-    """Find a directory that ends with the expected name."""
-    logger.debug(
-        'looking_for_suffix_match',
-        suffix=expected_name,
-        directory=str(install_dir),
-    )
-    for item in install_dir.iterdir():
-        if item.is_dir() and item.name.endswith(expected_name):
-            logger.debug('suffix_match_found', match=item.name)
-            return item
-    logger.debug('no_suffix_match_found', expected=expected_name)
-    return None
-
-
-def find_by_similarity(install_dir: Path, expected_name: str) -> Path | None:
-    """Find a directory with the highest similarity to the expected name."""
-    logger.debug(
-        'looking_for_similarity_match',
-        expected=expected_name,
-        directory=str(install_dir),
-    )
-    best_match = None
-    best_ratio = 0.6  # Minimum similarity threshold
-
-    for item in install_dir.iterdir():
-        if item.is_dir() and not item.name.startswith('.') and not item.name.endswith('.dist-info'):
-            ratio = SequenceMatcher(
-                None,
-                expected_name.lower(),
-                item.name.lower(),
-            ).ratio()
-            if ratio > best_ratio:
-                best_ratio = ratio
-                best_match = item
-
-    if best_match:
-        logger.debug(
-            'similarity_match_found',
-            match=best_match.name,
-            ratio=best_ratio,
-        )
-        return best_match
-
-    logger.debug('no_similarity_match_found', expected=expected_name)
-    return None
-
-
-def find_first_directory(install_dir: Path) -> Path | None:
-    """Find the first non-hidden, non-dist-info directory."""
-    logger.debug('looking_for_first_directory', directory=str(install_dir))
-    for item in install_dir.iterdir():
-        if item.is_dir() and not item.name.startswith('.') and not item.name.endswith('.dist-info'):
-            logger.debug('first_directory_found', directory=item.name)
-            return item
-    logger.debug('no_suitable_directory_found', directory=str(install_dir))
-    return None
-
-
-def _try_package_root_strategies(
+def _search_in_platform_subdirs(
     install_dir: Path,
     expected_name: str,
     target_subdir: str,
 ) -> Path | None:
-    strategies = [
-        find_exact_match,
-        find_python_package,
-        find_with_resources,
-        find_by_prefix,
-        find_by_suffix,
-        find_by_similarity,
-        find_first_directory,
-    ]
-    for strategy in strategies:
-        if strategy in [
-            find_python_package,
-            find_with_resources,
-            find_first_directory,
-        ]:
-            result = strategy(install_dir)
-        else:
-            result = strategy(install_dir, expected_name)
+    """Search for package in platform-specific subdirectories (Windows: Lib/, lib/, lib64/)."""
+    for subdir_name in ['Lib', 'lib', 'lib64']:
+        subdir_path = install_dir / subdir_name
+        if not (subdir_path.exists() and subdir_path.is_dir()):
+            continue
+
+        logger.debug('searching_in_platform_subdir', subdir=subdir_name)
+
+        # Try exact match in this subdir
+        result = _find_exact_package_match(subdir_path, expected_name)
         if result and (result / target_subdir).exists():
             logger.debug(
-                'package_root_found',
-                strategy=strategy.__name__,
+                'package_found_in_platform_subdir',
                 path=str(result),
+                subdir=subdir_name,
                 target_subdir=target_subdir,
             )
             return result
-    return None
 
-
-def _search_in_subdir_and_site_packages(
-    subdir_path: Path,
-    subdir_name: str,
-    expected_name: str,
-    target_subdir: str,
-) -> Path | None:  # pragma: no cover - Windows-specific
-    """Search for package in a subdirectory and its site-packages."""
-    logger.debug('retrying_in_subdirectory', subdir=subdir_name)
-    result = _try_package_root_strategies(
-        subdir_path,
-        expected_name,
-        target_subdir,
-    )
-    if result:
-        logger.debug(
-            'package_root_found',
-            strategy='subdir',
-            path=str(result),
-            subdir=subdir_name,
-        )
-        return result
-
-    # Also try site-packages within this subdir (common on Windows)
-    site_packages_path = subdir_path / 'site-packages'
-    if site_packages_path.exists() and site_packages_path.is_dir():
-        logger.debug(
-            'retrying_in_site_packages',
-            subdir=subdir_name,
-            site_packages=str(site_packages_path),
-        )
-        result = _try_package_root_strategies(
-            site_packages_path,
-            expected_name,
-            target_subdir,
-        )
-        if result:
+        # Also try site-packages within this subdir (common on Windows)
+        site_packages_path = subdir_path / 'site-packages'
+        if site_packages_path.exists() and site_packages_path.is_dir():
             logger.debug(
-                'package_root_found',
-                strategy='site_packages',
-                path=str(result),
+                'searching_in_site_packages',
                 subdir=subdir_name,
+                site_packages=str(site_packages_path),
             )
-            return result
-    return None
-
-
-def _try_windows_lib_subdirs(
-    install_dir: Path,
-    expected_name: str,
-    target_subdir: str,
-) -> Path | None:  # pragma: no cover - Windows-specific
-    """Try common Windows subdirs (Lib/, lib/, lib64/) and site-packages for package root."""
-    for subdir in ['Lib', 'lib', 'lib64']:
-        subdir_path = install_dir / subdir
-        if subdir_path.exists() and subdir_path.is_dir():
-            result = _search_in_subdir_and_site_packages(
-                subdir_path,
-                subdir,
+            result = _find_exact_package_match(
+                site_packages_path,
                 expected_name,
-                target_subdir,
             )
-            if result:
+            if result and (result / target_subdir).exists():
+                logger.debug(
+                    'package_found_in_site_packages',
+                    path=str(result),
+                    subdir=subdir_name,
+                    target_subdir=target_subdir,
+                )
                 return result
     return None
 
@@ -263,12 +110,17 @@ def find_package_root(
     expected_name: str,
     target_subdir: str = 'resources',
 ) -> Path:
-    """Find the actual package directory after installation using multiple strategies."""
+    """Find the package directory using precise, CLI-driven detection.
+
+    This function only uses exact matches and platform-specific subdirectory search.
+    All fuzzy search strategies have been removed to avoid incorrect matches.
+    """
     logger.debug(
         'looking_for_package_root',
         expected=expected_name,
         install_dir=str(install_dir),
     )
+
     # List all items for debugging
     try:
         items = list(install_dir.iterdir())
@@ -285,8 +137,18 @@ def find_package_root(
         msg = f'Error accessing install directory {install_dir}: {e}'
         raise RuntimeError(msg) from e
 
-    # Try strategies at the top level
-    result = _try_package_root_strategies(
+    # Try exact match at the top level first
+    result = _find_exact_package_match(install_dir, expected_name)
+    if result and (result / target_subdir).exists():
+        logger.debug(
+            'package_root_found_exact_match',
+            path=str(result),
+            target_subdir=target_subdir,
+        )
+        return result
+
+    # Try platform-specific subdirs (Windows: Lib/, lib/, lib64/)
+    result = _search_in_platform_subdirs(
         install_dir,
         expected_name,
         target_subdir,
@@ -294,16 +156,12 @@ def find_package_root(
     if result:
         return result
 
-    # Try common subdirs (Windows: Lib/, lib/, lib64/)
-    result = _try_windows_lib_subdirs(install_dir, expected_name, target_subdir)
-    if result:
-        return result  # pragma: no cover - we may hit this in CI but not in mac or linux
-
-    # If all strategies fail, provide detailed error
+    # If exact match fails, provide detailed error
     logger.error(
         'package_root_not_found',
         expected=expected_name,
         install_dir=str(install_dir),
+        target_subdir=target_subdir,
     )
     logger.error(
         'available_directories',
@@ -313,7 +171,7 @@ def find_package_root(
             if item.is_dir() and not item.name.startswith('.') and not item.name.endswith('.dist-info')
         ],
     )
-    msg = f'Package root {expected_name} not found in {install_dir} (and common subdirs)'
+    msg = f'Package "{expected_name}" not found in {install_dir}'
     raise RuntimeError(msg)
 
 


### PR DESCRIPTION
If package has a dependency that also has "resources" then in some cases (random really) it will create a link to the the dependency resources instead of the package "resources". This cleans up the search algorithm and only attempt to search for.. windows