### PR TITLE
chore(release): 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ This changelog is automatically generated using
 
 View [unreleased changes][unreleased] since the last release.
 
+## [1.1.0] <a name="1.1.0" href="#1.1.0">-</a> January 26, 2026
+
+### 🚀 Features
+
+- Support ghes by [@jamestrousdale](https://github.com/jamestrousdale)
+- Support alternative index URL for python packages (#15) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#15](https://github.com/hotdog-werx/pkglink/pull/15)
+- Apply repolish to project (#18) by
+  [@jmlopez-rod](https://github.com/jmlopez-rod) in
+  [#18](https://github.com/hotdog-werx/pkglink/pull/18)
+
+### 🐛 Bug Fixes
+
+- Remove per-source server, instead rely on GITHUB_SERVER_URL by
+  [@jamestrousdale](https://github.com/jamestrousdale)
+
+### ⚙️ Miscellaneous Tasks
+
+- Formatting by [@jamestrousdale](https://github.com/jamestrousdale)
+- Fix typing by [@jamestrousdale](https://github.com/jamestrousdale)
+- Dprint format by [@jamestrousdale](https://github.com/jamestrousdale)
+
+[1.1.0]: https://github.com/hotdog-werx/pkglink/compare/1.0.1...1.1.0
+
 ## [0.0.1] <a name="0.0.1" href="#0.0.1">-</a> September 10, 2025
 
 [0.0.1]: https://github.com/hotdog-werx/pkglink/tree/0.0.1


### PR DESCRIPTION
## [1.1.0] <a name="1.1.0" href="#1.1.0">-</a> January 26, 2026
### 🚀 Features
- Support ghes by [@jamestrousdale](https://github.com/jamestrousdale)
- Support alternative index URL for python packages (#15) by [@jamestrousdale](https://github.com/jamestrousdale) in [#15](https://github.com/hotdog-werx/pkglink/pull/15)
- Apply repolish to project (#18) by [@jmlopez-rod](https://github.com/jmlopez-rod) in [#18](https://github.com/hotdog-werx/pkglink/pull/18)
### 🐛 Bug Fixes
- Remove per-source server, instead rely on GITHUB_SERVER_URL by [@jamestrousdale](https://github.com/jamestrousdale)
### ⚙️ Miscellaneous Tasks
- Formatting by [@jamestrousdale](https://github.com/jamestrousdale)
- Fix typing by [@jamestrousdale](https://github.com/jamestrousdale)
- Dprint format by [@jamestrousdale](https://github.com/jamestrousdale)

[1.1.0]: https://github.com/hotdog-werx/pkglink/compare/1.0.1...1.1.0
